### PR TITLE
fix: add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "js2xmlparser": "^4.0.1",
     "lodash": "^4.17.21",
     "lru-cache": "^6.0.0",
+    "request": "^2.88.2",
     "request-promise": "^4.2.5",
     "source-map-support": "^0.5.5",
     "xml2js": "^0.4.23",


### PR DESCRIPTION
The below error occurred when load this module.

```
Error: Cannot find module 'request'
Require stack:
- /Users/kazu/headspinio/appium-roku-driver/node_modules/request-promise/lib/rp.js
- /Users/kazu/headspinio/appium-roku-driver/build/lib/commands/roku.js
- /Users/kazu/headspinio/appium-roku-driver/build/lib/commands/index.js
- /Users/kazu/headspinio/appium-roku-driver/build/lib/driver.js
- /Users/kazu/headspinio/appium-roku-driver/build/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at /Users/kazu/headspinio/appium-roku-driver/node_modules/request-promise/lib/rp.js:11:16
    at module.exports (/Users/kazu/headspinio/appium-roku-driver/node_modules/stealthy-require/lib/index.js:62:23)
    at Object.<anonymous> (/Users/kazu/headspinio/appium-roku-driver/node_modules/request-promise/lib/rp.js:10:19)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/Users/kazu/headspinio/appium-roku-driver/lib/commands/roku.js:2:1)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/Users/kazu/headspinio/appium-roku-driver/lib/commands/index.js:1:1)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
```

Btw, `requests` has been deprecated.
As same as Appium, this module also should move to `axios` based one. I'll update them shortly, but let me merge this for now.

@jlipps 